### PR TITLE
Allow to set log handler, formatter and name

### DIFF
--- a/django_audit_log/app_settings.py
+++ b/django_audit_log/app_settings.py
@@ -1,0 +1,11 @@
+
+from django.conf import settings
+
+# Internal logger name used by the audit log. Leave None to use python-audit-log default ('audit_log')
+LOGGER_NAME = getattr(settings, 'AUDIT_LOG_LOGGER_NAME', None)
+
+# Log handler that determines what to do with the logs. Leave None to use python-audit-log default (write to stdout)
+LOG_HANDLER_CALLABLE_PATH = getattr(settings, 'AUDIT_LOG_HANDLER_CALLABLE_PATH', None)
+
+# Log formatter that determines log formatting. Leave None to use python-audit-log default (AuditLogFormatter)
+LOG_FORMATTER_CALLABLE_PATH = getattr(settings, 'AUDIT_LOG_FORMATTER_CALLABLE_PATH', None)

--- a/django_audit_log/util.py
+++ b/django_audit_log/util.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 
 from django.http import HttpRequest
@@ -15,3 +16,8 @@ def get_client_ip(request: HttpRequest) -> str:
         logger = logging.getLogger(__name__)
         logger.warning('Failed to get ip for audit log', exc_info=True)
         return 'failed to get ip'
+
+
+def import_callable(path):
+    module, method = path.rsplit('.', 1)
+    return getattr(importlib.import_module(module), method)

--- a/tests/rest_framework/test_viewsets.py
+++ b/tests/rest_framework/test_viewsets.py
@@ -1,11 +1,11 @@
 from unittest import mock
 
 from django.contrib.auth.models import User
-from django.test import TestCase, RequestFactory
-from rest_framework.filters import SearchFilter, OrderingFilter
-from rest_framework.response import Response
+from django.test import RequestFactory, TestCase
 
 from django_audit_log.rest_framework.viewsets import AuditLogReadOnlyViewSet, AuditLogViewSet
+from rest_framework.filters import OrderingFilter, SearchFilter
+from rest_framework.response import Response
 
 
 class DynamicReadOnlyViewSet(AuditLogReadOnlyViewSet):
@@ -96,7 +96,8 @@ class TestAuditLogReadOnlyViewset(TestCase):
     @mock.patch('rest_framework.mixins.ListModelMixin.list')
     def test_list_without_results_with_filter(self, mocked_list):
         mocked_list.return_value = Response(data=['test1', 'test2'])
-        view_set = DynamicReadOnlyViewSet(queryset=User.objects.all(), filter_backends=[SearchFilter], search_fields=['email'])
+        view_set = DynamicReadOnlyViewSet(
+            queryset=User.objects.all(), filter_backends=[SearchFilter], search_fields=['email'])
         request = self.factory.get('/')
         request.query_params = {'search': 'test'}
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from django.http import HttpRequest
 
-from django_audit_log.util import get_client_ip
+from django_audit_log.util import get_client_ip, import_callable
 
 
 class TestUtil(TestCase):
@@ -22,3 +22,12 @@ class TestUtil(TestCase):
     def test_get_client_ip_exception(self, mocked_logger):
         self.assertEqual(get_client_ip(request=None), 'failed to get ip')
         mocked_logger.assert_called_with('Failed to get ip for audit log', exc_info=True)
+
+    def test_import_callable(self):
+        path = 'tests.test_util.callable_for_test'
+        callable = import_callable(path)
+        self.assertEqual(callable(), 'success')
+
+
+def callable_for_test():
+    return 'success'


### PR DESCRIPTION
From the settings it is now possible to set the log handler,
formatter and name. This allows for overriding the defaults.